### PR TITLE
Fixed typographical error, changed Carribean to Caribbean in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ both client and server generate these files ahead of time knowing the integer se
 
 
 They can be real files but that involes pulling the data of the respective file
-(eg. Pirates of the Carribean) ahead of time.
+(eg. Pirates of the Caribbean) ahead of time.
 
 This is considered good enough since, as discussed in the README.md, it doesn't make it
 easier to detect in real-time and bit-smuggler will be detected anyway on a slow path.


### PR DESCRIPTION
danoctavian, I've corrected a typographical error in the documentation of the [bit-smuggler](https://github.com/danoctavian/bit-smuggler) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
